### PR TITLE
Create script to hold logic for Kalibro start

### DIFF
--- a/start_kalibro_services.sh
+++ b/start_kalibro_services.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Bash unofficial strict mode: http://www.redsymbol.net/articles/unofficial-bash-strict-mode/
+set -e
+set -o pipefail
+IFS=$'\n\t'
+
+pushd kalibro_processor
+  export BUNDLE_GEMFILE=$PWD/Gemfile
+  RAILS_ENV=local bundle exec rails s -p 8082 -d
+  RAILS_ENV=local bundle exec bin/delayed_job start
+  unset BUNDLE_GEMFILE BUNDLE_PATH
+popd
+
+pushd kalibro_configurations
+  export BUNDLE_GEMFILE=$PWD/Gemfile
+  bundle exec rails s -p 8083 -d
+  unset BUNDLE_GEMFILE BUNDLE_PATH
+popd


### PR DESCRIPTION
If you choose to not start the services after installation, a script to
do so becomes useful.

This fixes #1 
